### PR TITLE
Feature/return response on 403

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/workspace.xml
+.DS_Store

--- a/bluefireIdentity.js
+++ b/bluefireIdentity.js
@@ -89,10 +89,10 @@ angular.module('BluefireIdentity').factory('bluefireIdentity', [ '$q', '$cookies
       console.log('Redirecting to: ' + redirectString);
       debugger;
       window.location = redirectString;
-      return;
+      return response;
+    } else {
+      return $q.reject(response);
     }
-    // otherwise
-    return $q.reject(response);
   }
 
   // $http Interceptor function

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bluefire-identity-js",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://github.com/BluefireProductions/bluefire-identity-js",
   "authors": [
     "Timothy Jones <palantar@gmail.com>",


### PR DESCRIPTION
This feature is to return the response object when we intercept an HTTP request with response status 403. Previously we returned undefined which meant that any subsequent chained promise handlers were unable to access the response object. Returning the response allows for us to handle the 403 response elsewhere, for instance, when deciding whether or not to show an error message when we get a 403 response.
